### PR TITLE
Fix potential vulnerability in CI workflow

### DIFF
--- a/.github/workflows/cloud-benchmarking-workflow.yml
+++ b/.github/workflows/cloud-benchmarking-workflow.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Set Initial Variables
         # By default we use 1Hr benchmarks
         run: |

--- a/.github/workflows/cloud-benchmarking-workflow.yml
+++ b/.github/workflows/cloud-benchmarking-workflow.yml
@@ -43,8 +43,8 @@ jobs:
       # conditionally overwrite variables if a tag was the triggering event
       - name: Reset Initial Variables for pull request
         run: |
-          echo "GITHUB_SHA_SHORT=`echo ${{ github.event.pull_request.head.sha }} | cut -c1-7`" >> $GITHUB_ENV
-          echo "COMMIT_NAME=`echo ${{ github.event.pull_request.head.sha }} | cut -c1-7`" >> $GITHUB_ENV
+          echo "GITHUB_SHA_SHORT=${{ github.event.pull_request.head.sha | substr(0, 7) }}" >> $GITHUB_ENV
+          echo "COMMIT_NAME=${{ github.event.pull_request.head.sha | substr(0, 7) }}" >> $GITHUB_ENV
         if: github.event_name == 'pull_request'
       - name: Reset Variables For Tags
         # We do a 1Month benchmark for tags

--- a/.github/workflows/gcclassic-compile-tests.yml
+++ b/.github/workflows/gcclassic-compile-tests.yml
@@ -19,6 +19,8 @@ jobs:
 
     steps:
       - name: Checkout code
+        with:
+          persist-credentials: false
         uses: actions/checkout@v4
 
       - name: Install dependencies


### PR DESCRIPTION
Supersedes #1.

As noted in https://github.com/geoschem/GCClassic/pull/86, without the edits to the cloud benchmarking workflow in this PR, the zizmor GitHub Actions static analysis tool reports:
```
error[template-injection]: code injection via template expansion
  --> /home/joe/software/GCClassic/.github/workflows/cloud-benchmarking-workflow.yml:45:9
   |
45 |         - name: Reset Initial Variables for pull request
   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
46 | /         run: |
47 | |           echo "GITHUB_SHA_SHORT=`echo ${{ github.event.pull_request.head.sha }} | cut -c1-7`" >> $GITHUB_ENV
48 | |           echo "COMMIT_NAME=`echo ${{ github.event.pull_request.head.sha }} | cut -c1-7`" >> $GITHUB_ENV
   | |________________________________________________________________________________________________________^ github.event.pull_request.head.sha may expand into attacker-controllable code
   |
   = note: audit confidence → High

error[template-injection]: code injection via template expansion
  --> /home/joe/software/GCClassic/.github/workflows/cloud-benchmarking-workflow.yml:45:9
   |
45 |         - name: Reset Initial Variables for pull request
   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
46 | /         run: |
47 | |           echo "GITHUB_SHA_SHORT=`echo ${{ github.event.pull_request.head.sha }} | cut -c1-7`" >> $GITHUB_ENV
48 | |           echo "COMMIT_NAME=`echo ${{ github.event.pull_request.head.sha }} | cut -c1-7`" >> $GITHUB_ENV
   | |________________________________________________________________________________________________________^ github.event.pull_request.head.sha may expand into attacker-controllable code
   |
   = note: audit confidence → High
```